### PR TITLE
Account for multiples of the same item in the cart.

### DIFF
--- a/services/CartBundleService.php
+++ b/services/CartBundleService.php
@@ -42,23 +42,20 @@ class CartBundleService extends BaseApplicationComponent
   {
     // Get the current cart
     $cart = craft()->commerce_cart->getCart();
-    $cartItemsCount = count( $cart->lineItems );
+    $lineItems = $cart->lineItems;
 
     // Only worry about doing more processing if there are enough items in the cart to bundle
-    if ( $cartItemsCount > 1 ) {
+    if ( count( $lineItems ) > 1 ) {
       $lineItems = $this->bundleItems( $cart->lineItems );
-
-      $qty = 0;
-
-      foreach ( $lineItems as $item ) {
-        $qty += $item->qty;
-      }
-
-      $cartItemsCount = $qty;
-
     }
 
-    return $cartItemsCount;
+    $qty = 0;
+
+    foreach ( $lineItems as $item ) {
+      $qty += $item->qty;
+    }
+
+    return $qty;
   }
 
   /**

--- a/services/CartBundleService.php
+++ b/services/CartBundleService.php
@@ -47,7 +47,15 @@ class CartBundleService extends BaseApplicationComponent
     // Only worry about doing more processing if there are enough items in the cart to bundle
     if ( $cartItemsCount > 1 ) {
       $lineItems = $this->bundleItems( $cart->lineItems );
-      $cartItemsCount = count( $lineItems );
+
+      $qty = 0;
+
+      foreach ( $lineItems as $item ) {
+        $qty += $item->qty;
+      }
+
+      $cartItemsCount = $qty;
+
     }
 
     return $cartItemsCount;


### PR DESCRIPTION
If a user adds more than one of an item, the plugin wouldn't reflect that in the `cartItemsCount` output. This PR  adds functionality to iterate through `$lineItems` after bundling items, properly adding up the item quantities.